### PR TITLE
Fix hardcoded simpleDic.txt wasn't moving because it does not exist

### DIFF
--- a/files/configureFiles.pl
+++ b/files/configureFiles.pl
@@ -1,3 +1,5 @@
+use File::Basename;
+
 my $serverPath = '/opt/WSC/AppServer';
 my $server_config_path = "$serverPath/AppServerX.xml";
 
@@ -52,11 +54,14 @@ sub configureUserAndCustomDictionaries
 	{
 		system("mv $serverPath/CustDictConfig.xml $cust_dict_conf");
 	}
-
-	my $cust_dict_sample = "$cust_dicts_path/sampleDic.txt";
-	if (! -e $cust_dict_sample)
+	
+	for my $file (<$serverPath/CustomDictionaries/*.txt>)
 	{
-		system("mv $serverPath/CustomDictionaries/sampleDic.txt $cust_dict_sample");
+		my $file_name = basename($file);
+		if (! -e "$cust_dicts_path/$file_name")
+		{
+			system("mv $file $cust_dicts_path/");
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes trouble in `configureFiles.pl` tries to move `sampleDic.txt` file and it doesn't exist. Now all files from `CustomDictionaries` are moved to dictionary directory.