### PR TITLE
Use absolute path in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ ARG LICENSE_DIR=/var/lib/wsc/license
 ARG USER_ID=2000
 ARG GROUP_ID=2000
 
+ENV APP_SERVER_DIR=${APP_SERVER_DIR}
+
 ENV WSC_AUTO_INSTALL=TRUE
 
 # Application installation parameters
@@ -119,5 +121,7 @@ RUN chown -R ${USER_ID}:${GROUP_ID} /var/log/nginx \
         /etc/nginx
 
 USER $USER_NAME
+
 WORKDIR $APP_SERVER_DIR
-ENTRYPOINT ["./startService.sh"]
+
+ENTRYPOINT sh ${APP_SERVER_DIR}/startService.sh

--- a/DockerfileCentOS
+++ b/DockerfileCentOS
@@ -27,6 +27,8 @@ ARG LICENSE_DIR=/var/lib/wsc/license
 ARG USER_ID=2000
 ARG GROUP_ID=2000
 
+ENV APP_SERVER_DIR=${APP_SERVER_DIR}
+
 ENV WSC_AUTO_INSTALL=TRUE
 
 # Application installation parameters
@@ -126,5 +128,7 @@ RUN chown -R ${USER_ID}:${GROUP_ID} /var/log/nginx \
         /etc/nginx
 
 USER $USER_NAME
+
 WORKDIR $APP_SERVER_DIR
-ENTRYPOINT ["./startService.sh"]
+
+ENTRYPOINT sh ${APP_SERVER_DIR}/startService.sh

--- a/DockerfileRedHat
+++ b/DockerfileRedHat
@@ -27,6 +27,8 @@ ARG LICENSE_DIR=/var/lib/wsc/license
 ARG USER_ID=2000
 ARG GROUP_ID=2000
 
+ENV APP_SERVER_DIR=${APP_SERVER_DIR}
+
 ENV WSC_AUTO_INSTALL=TRUE
 
 # Application installation parameters
@@ -125,5 +127,7 @@ RUN chown -R ${USER_ID}:${GROUP_ID} /var/log/nginx \
         /etc/nginx
 
 USER $USER_NAME
+
 WORKDIR $APP_SERVER_DIR
-ENTRYPOINT ["./startService.sh"]
+
+ENTRYPOINT sh ${APP_SERVER_DIR}/startService.sh


### PR DESCRIPTION
This PR makes `ENTRYPOINT` use the absolute path to the `startService.sh` script, so it can be found when an image is used as a base for another image.