### PR TITLE
Remove lxml dependency from DockerfileCentOS

### DIFF
--- a/DockerfileCentOS
+++ b/DockerfileCentOS
@@ -102,7 +102,8 @@ RUN yum update -y --skip-broken && \
     yum clean all && rm -rf /var/cache/yum && \
     rm -rf /etc/nginx/conf.d/default.conf /usr/share/nginx/html/* && \
     rm -rf /var/log/nginx/* && \
-    ln -sf /dev/stderr /var/log/nginx/error.log
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    rm -rf /usr/lib64/python2.7/site-packages/*lxml*
 
 RUN groupadd --gid ${GROUP_ID} $USER_NAME && useradd --no-log-init --uid ${USER_ID} --gid ${GROUP_ID} $USER_NAME
 


### PR DESCRIPTION
Older versions of lxml have known vulnerabilities, while WProofreader is not using it directly