### PR TITLE
WP-6869: Allow unrestricted domain and root path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
-ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 # Specify license ticket ID to activate the license during the image build. For example, WPR_LICENSE_TICKET_ID = 6u*************ZO
 ARG WPR_LICENSE_TICKET_ID
@@ -54,7 +52,6 @@ ARG WPR_ACCESS_KEY
 ENV WPR_CONFIG_USE_ENV=true
 ENV WPR_FILE_OWNER=${WPR_USER_ID}:${WPR_GROUP_ID}
 ENV WPR_PROTOCOL=${WPR_PROTOCOL}
-ENV WPR_DOMAIN_NAME=${WPR_DOMAIN_NAME}
 ENV WPR_WEB_PORT=${WPR_WEB_PORT}
 ENV WPR_VIRTUAL_DIR=${WPR_VIRTUAL_DIR}
 ENV WPR_WEB_SERVER_TYPE=2

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-ARG WPR_DOMAIN_NAME=localhost
+# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
+ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 # Specify license ticket ID to activate the license during the image build. For example, WPR_LICENSE_TICKET_ID = 6u*************ZO
 ARG WPR_LICENSE_TICKET_ID

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -41,7 +41,8 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-ARG WPR_DOMAIN_NAME=localhost
+# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
+ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 # Specify license ticket ID to activate the license during the image build. For example, WPR_LICENSE_TICKET_ID = 6u*************ZO
 ARG WPR_LICENSE_TICKET_ID

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -41,8 +41,6 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
-ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 # Specify license ticket ID to activate the license during the image build. For example, WPR_LICENSE_TICKET_ID = 6u*************ZO
 ARG WPR_LICENSE_TICKET_ID
@@ -61,7 +59,6 @@ ARG WPR_ACCESS_KEY
 ENV WPR_CONFIG_USE_ENV=true
 ENV WPR_FILE_OWNER=${WPR_USER_ID}:${WPR_GROUP_ID}
 ENV WPR_PROTOCOL=${WPR_PROTOCOL}
-ENV WPR_DOMAIN_NAME=${WPR_DOMAIN_NAME}
 ENV WPR_WEB_PORT=${WPR_WEB_PORT}
 ENV WPR_VIRTUAL_DIR=${WPR_VIRTUAL_DIR}
 ENV WPR_WEB_SERVER_TYPE=2

--- a/Dockerfile.ubuntu-prebuilt
+++ b/Dockerfile.ubuntu-prebuilt
@@ -101,8 +101,6 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
-ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 ARG WPR_LICENSE_TICKET_ID
 
@@ -119,7 +117,6 @@ ARG WPR_ACCESS_KEY
 
 ENV WPR_CONFIG_USE_ENV=true
 ENV WPR_PROTOCOL=${WPR_PROTOCOL}
-ENV WPR_DOMAIN_NAME=${WPR_DOMAIN_NAME}
 ENV WPR_WEB_PORT=${WPR_WEB_PORT}
 ENV WPR_VIRTUAL_DIR=${WPR_VIRTUAL_DIR}
 ENV WPR_LICENSE_TICKET_ID=${WPR_LICENSE_TICKET_ID}

--- a/Dockerfile.ubuntu-prebuilt
+++ b/Dockerfile.ubuntu-prebuilt
@@ -101,7 +101,8 @@ ENV WPR_APP_SERVER_DIR=${WPR_APP_SERVER_DIR}
 ARG WPR_PROTOCOL=2
 # Web port outside the container. If value isn't specified (e.g. empty), the default value will be used (443 for HTTPS and 80 for HTTP).
 ARG WPR_WEB_PORT
-ARG WPR_DOMAIN_NAME=localhost
+# Domain name for NGINX server_name directive. Default '_' accepts any domain. Set to specific domain to restrict access.
+ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 ARG WPR_LICENSE_TICKET_ID
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If, on the other hand, you would like to use a prebuilt Docker image, choose the
 ```
 ARG WPR_PROTOCOL=2
 ARG WPR_WEB_PORT
-ARG WPR_DOMAIN_NAME=localhost
+ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 ARG WPR_LICENSE_TICKET_ID
 ```
@@ -47,10 +47,10 @@ English language and autocomplete models are available for en_US (American Engli
 ```
 ARG WPR_LICENSE_TICKET_ID=6u*************ZO
 ```
-* Specify `DOMAIN_NAME` which will be used for the setup of demo samples with WProofreader. By default, `localhost` will be used if nothing is specified.
+* Configure domain name for NGINX `server_name` directive. By default, `_` (underscore) is used, which accepts requests from any domain. To restrict access to a specific domain, set this to your domain name (e.g., `example.com`).
 
 ```
-ARG WPR_DOMAIN_NAME = DOMAIN_NAME
+ARG WPR_DOMAIN_NAME=_
 ```
 
 If `WPR_LICENSE_TICKET_ID` was specified during the image creation, you don't need to specify it during the launch of `docker run` command.
@@ -167,7 +167,7 @@ docker run -d -p 443:8443 --env WPR_PROTOCOL=1 --env WPR_DOMAIN_NAME=localhost -
 where:
 
 * `--env WPR_PROTOCOL=1` start a container on HTTPS protocol
-* `--env WPR_DOMAIN_NAME=localhost` start a container on `localhost` domain name
+* `--env WPR_DOMAIN_NAME=localhost` configure NGINX to accept requests only from `localhost` domain. Use `_` to accept requests from any domain.
 * `--env WPR_WEB_PORT=443` configure `443` port to be an external port of a container
 * `--env WPR_VIRTUAL_DIR=wscservice` start a container with `wscservice` as virtual dir
 * `--env WPR_LICENSE_TICKET_ID=6u*************ZO` activate license on container start with `6u*************ZO` license ticket id

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ If, on the other hand, you would like to use a prebuilt Docker image, choose the
 ```
 ARG WPR_PROTOCOL=2
 ARG WPR_WEB_PORT
-ARG WPR_DOMAIN_NAME=_
 ARG WPR_VIRTUAL_DIR=wscservice
 ARG WPR_LICENSE_TICKET_ID
 ```
@@ -47,12 +46,6 @@ English language and autocomplete models are available for en_US (American Engli
 ```
 ARG WPR_LICENSE_TICKET_ID=6u*************ZO
 ```
-* Configure domain name for NGINX `server_name` directive. By default, `_` (underscore) is used, which accepts requests from any domain. To restrict access to a specific domain, set this to your domain name (e.g., `example.com`).
-
-```
-ARG WPR_DOMAIN_NAME=_
-```
-
 * Configure virtual directory for the service. By default, `wscservice` is used, making the service accessible at `/wscservice/` (e.g., `http://localhost/wscservice/`). To deploy at the root path, set this to `/` or leave it empty:
 
 ```
@@ -162,7 +155,6 @@ Note: The container user must have read permissions for the certificate files.
 Alternatively, these parameters can be changed on the container running by passing them as environment variables:
 
 * `WPR_PROTOCOL`
-* `WPR_DOMAIN_NAME`
 * `WPR_WEB_PORT`
 * `WPR_VIRTUAL_DIR`
 * `WPR_LICENSE_TICKET_ID`
@@ -170,13 +162,12 @@ Alternatively, these parameters can be changed on the container running by passi
 For example:
 
 ```
-docker run -d -p 443:8443 --env WPR_PROTOCOL=1 --env WPR_DOMAIN_NAME=localhost --env WPR_WEB_PORT=443 --env WPR_VIRTUAL_DIR=wscservice --env WPR_LICENSE_TICKET_ID=6u*************ZO local/wsc_app:x.x.x
+docker run -d -p 443:8443 --env WPR_PROTOCOL=1 --env WPR_WEB_PORT=443 --env WPR_VIRTUAL_DIR=wscservice --env WPR_LICENSE_TICKET_ID=6u*************ZO local/wsc_app:x.x.x
 ```
 
 where:
 
 * `--env WPR_PROTOCOL=1` start a container on HTTPS protocol
-* `--env WPR_DOMAIN_NAME=localhost` configure NGINX to accept requests only from `localhost` domain. Use `_` to accept requests from any domain.
 * `--env WPR_WEB_PORT=443` configure `443` port to be an external port of a container
 * `--env WPR_VIRTUAL_DIR=wscservice` start a container with `wscservice` as virtual directory. Use `/` or empty string for root path.
 * `--env WPR_LICENSE_TICKET_ID=6u*************ZO` activate license on container start with `6u*************ZO` license ticket id
@@ -283,7 +274,6 @@ services:
     environment:
       - WPR_PROTOCOL=2
       - WPR_WEB_PORT=80
-      - WPR_DOMAIN_NAME=localhost
       - WPR_VIRTUAL_DIR=wscservice
 ```
 
@@ -298,7 +288,6 @@ Notes:
     environment:
       - WPR_PROTOCOL=1
       - WPR_WEB_PORT=443
-      - WPR_DOMAIN_NAME=localhost
       - WPR_VIRTUAL_DIR=wscservice
 ```
 3. For HTTPS communication you can provide your certificate file and key, as a pair of files named `cert.pem` and `key.pem` by default (configurable via `WPR_CERT_FILE_NAME` and `WPR_CERT_KEY_NAME`). If no certificates are mounted, self-signed certificates will be generated automatically at startup. To use your own certificates — for instance, if they are kept in a folder `/home/user/certificate` — add the following section to `docker-compose.yml`:
@@ -324,7 +313,6 @@ services:
     environment:
       - WPR_PROTOCOL=1
       - WPR_WEB_PORT=443
-      - WPR_DOMAIN_NAME=localhost
       - WPR_VIRTUAL_DIR=wscservice
       - WPR_LICENSE_TICKET_ID=ABCD1234
     volumes:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ ARG WPR_LICENSE_TICKET_ID=6u*************ZO
 ARG WPR_DOMAIN_NAME=_
 ```
 
+* Configure virtual directory for the service. By default, `wscservice` is used, making the service accessible at `/wscservice/` (e.g., `http://localhost/wscservice/`). To deploy at the root path, set this to `/` or leave it empty:
+
+```
+ARG WPR_VIRTUAL_DIR=wscservice   # Service at /wscservice/ (default)
+ARG WPR_VIRTUAL_DIR=/            # Service at root / (captures all requests)
+```
+
+**Note:** Using root path (`/`) configures NGINX to serve the application at the domain root, which may not be suitable for shared web servers where multiple applications need different paths.
+
 If `WPR_LICENSE_TICKET_ID` was specified during the image creation, you don't need to specify it during the launch of `docker run` command.
 
 * If using a proxy server for network traffic, add the following proxy settings for automated license activation:
@@ -169,7 +178,7 @@ where:
 * `--env WPR_PROTOCOL=1` start a container on HTTPS protocol
 * `--env WPR_DOMAIN_NAME=localhost` configure NGINX to accept requests only from `localhost` domain. Use `_` to accept requests from any domain.
 * `--env WPR_WEB_PORT=443` configure `443` port to be an external port of a container
-* `--env WPR_VIRTUAL_DIR=wscservice` start a container with `wscservice` as virtual dir
+* `--env WPR_VIRTUAL_DIR=wscservice` start a container with `wscservice` as virtual directory. Use `/` or empty string for root path.
 * `--env WPR_LICENSE_TICKET_ID=6u*************ZO` activate license on container start with `6u*************ZO` license ticket id
 
 Additional parameters:

--- a/files/configureFiles.pl
+++ b/files/configureFiles.pl
@@ -4,10 +4,10 @@ my $serverPath = $ENV{'WPR_APP_SERVER_DIR'};
 my $installPath = "$serverPath/..";
 my $server_config_path = "$serverPath/AppServerX.xml";
 
-configureSamplesAndVirtualDir();
+printStartEndpoint();
 configureUserAndCustomDictionaries();
 
-sub configureSamplesAndVirtualDir
+sub printStartEndpoint
 {
 	my $protocol = $ENV{'WPR_PROTOCOL'} eq '1' ? 'https' : 'http';
 	my $host = $ENV{'WPR_DOMAIN_NAME'};
@@ -16,46 +16,9 @@ sub configureSamplesAndVirtualDir
 	my $web_port = $ENV{'WPR_WEB_PORT'} eq "" ? ($protocol eq "https" ? "443" : "80") : $ENV{'WPR_WEB_PORT'};
 	my $virtual_dir = $ENV{'WPR_VIRTUAL_DIR'};
 
-	configureVirtualDir($protocol, $host, $web_port, $virtual_dir);
-	
-	configureSamples($protocol, $host, $web_port, $virtual_dir);
-}
-
-sub configureSamples()
-{
-	my ($protocol, $host, $web_port, $virtual_dir) = @_;
-	
-	my $samples_dir_path = "$installPath/WebComponents/Samples/";
-	opendir my $dir, $samples_dir_path or return;
-	my @files = readdir $dir;
-	closedir $dir;
-
-	foreach ( @files )
-	{
-		if ( $_ eq '.' || $_ eq '..' ) { next; }
-
-		my %pairs = (
-			'serviceProtocol: \'((http)|(https))\'' => "serviceProtocol: '$protocol'",
-			'servicePort: \'\d*\'' => "servicePort: '$web_port'",
-			'serviceHost: \'[\w.-]*\'' => "serviceHost: '$host'",
-			'servicePath: \'.*?\/api\'' => "servicePath: '$virtual_dir/api'",
-			'((http)|(https)):\/\/[\w.-]*:\d*\/.*?\/wscbundle\/wscbundle.js' => "$protocol://$host:$web_port/$virtual_dir/wscbundle/wscbundle.js",
-			'((http)|(https)):\/\/[\w.-]*:\d*\/.*?\/samples\/' => "$protocol://$host:$web_port/$virtual_dir/samples/"
-		);
-		replaceFileContent(\%pairs, "$samples_dir_path/$_");
-	}
-}
-
-sub configureVirtualDir()
-{
-	my ($protocol, $host, $web_port, $virtual_dir) = @_;
-	
-	my $virtual_dir_file = "$installPath/WebComponents/WebInterface/index.html";
-	
-	replaceFileContent({'((http)|(https)):\/\/[\w.-]*:\d*\/.*?\/api\?cmd' => "$protocol://$host:$web_port/$virtual_dir/api?cmd"}, $virtual_dir_file);
-	replaceFileContent({'((http)|(https)):\/\/[\w.-]*:\d*\/.*?\/samples\/' => "$protocol://$host:$web_port/$virtual_dir/samples/"}, $virtual_dir_file);
-	
-	print "Verify the WSC Application Operability: $protocol://$host:$web_port/$virtual_dir/ \n";
+	# Print verification message
+	my $display_host = ($host eq '_') ? '<host>' : $host;
+	print "Verify the WSC Application Operability: $protocol://$display_host:$web_port/$virtual_dir/ \n";
 }
 
 sub configureUserAndCustomDictionaries

--- a/files/configureFiles.pl
+++ b/files/configureFiles.pl
@@ -16,9 +16,15 @@ sub printStartEndpoint
 	my $web_port = $ENV{'WPR_WEB_PORT'} eq "" ? ($protocol eq "https" ? "443" : "80") : $ENV{'WPR_WEB_PORT'};
 	my $virtual_dir = $ENV{'WPR_VIRTUAL_DIR'};
 
+	# Normalize virtual_dir for display
+	my $is_root_path = ($virtual_dir eq '/' || $virtual_dir eq '');
+	my $vdir_part = $is_root_path ? '' : $virtual_dir;
+	$vdir_part =~ s/^\///;  # Remove leading slash if present
+	$vdir_part = '/' . $vdir_part if $vdir_part ne '';  # Add it back with proper formatting
+
 	# Print verification message
 	my $display_host = ($host eq '_') ? '<host>' : $host;
-	print "Verify the WSC Application Operability: $protocol://$display_host:$web_port/$virtual_dir/ \n";
+	print "Verify the WSC Application Operability: $protocol://$display_host:$web_port$vdir_part/ \n";
 }
 
 sub configureUserAndCustomDictionaries

--- a/files/configureFiles.pl
+++ b/files/configureFiles.pl
@@ -10,8 +10,6 @@ configureUserAndCustomDictionaries();
 sub printStartEndpoint
 {
 	my $protocol = $ENV{'WPR_PROTOCOL'} eq '1' ? 'https' : 'http';
-	my $host = $ENV{'WPR_DOMAIN_NAME'};
-
 	# If user don't specify WEB_PORT, using default 80 for http and 443 for https
 	my $web_port = $ENV{'WPR_WEB_PORT'} eq "" ? ($protocol eq "https" ? "443" : "80") : $ENV{'WPR_WEB_PORT'};
 	my $virtual_dir = $ENV{'WPR_VIRTUAL_DIR'};
@@ -22,9 +20,7 @@ sub printStartEndpoint
 	$vdir_part =~ s/^\///;  # Remove leading slash if present
 	$vdir_part = '/' . $vdir_part if $vdir_part ne '';  # Add it back with proper formatting
 
-	# Print verification message
-	my $display_host = ($host eq '_') ? '<host>' : $host;
-	print "Verify the WSC Application Operability: $protocol://$display_host:$web_port$vdir_part/ \n";
+	print "Verify the WSC Application Operability: $protocol://<host>:$web_port$vdir_part/ \n";
 }
 
 sub configureUserAndCustomDictionaries

--- a/files/configureWebServer.pl
+++ b/files/configureWebServer.pl
@@ -53,18 +53,11 @@ sub configureNginxConfig
 		replaceFileContent('user\ [a-z0-9\-\_\.]+;\n', '', $nginxMainConf);
 	}
 	
-	my $host = $ENV{'WPR_DOMAIN_NAME'};
 	my $virtual_dir = $ENV{'WPR_VIRTUAL_DIR'};
 	my $is_root_path = ($virtual_dir eq '/' || $virtual_dir eq '');
 
 	if (-e $nginxConf)
 	{
-		if ($host ne "")
-		{
-			# Change server name inside NGINX config
-			replaceFileContent('server_name [\w.-]*;', "server_name $host;", $nginxConf);
-		}
-
 		# Normalize virtual_dir: remove leading/trailing slashes
 		$virtual_dir =~ s/^\///;
 		$virtual_dir =~ s/\/$//;

--- a/files/configureWebServer.pl
+++ b/files/configureWebServer.pl
@@ -55,7 +55,8 @@ sub configureNginxConfig
 	
 	my $host = $ENV{'WPR_DOMAIN_NAME'};
 	my $virtual_dir = $ENV{'WPR_VIRTUAL_DIR'};
-	
+	my $is_root_path = ($virtual_dir eq '/' || $virtual_dir eq '');
+
 	if (-e $nginxConf)
 	{
 		if ($host ne "")
@@ -63,15 +64,19 @@ sub configureNginxConfig
 			# Change server name inside NGINX config
 			replaceFileContent('server_name [\w.-]*;', "server_name $host;", $nginxConf);
 		}
-		
-		if ($virtual_dir ne "")
-		{
-			# Change virtual dir inside NGINX config
-			replaceFileContent('location \/.*? {', "location /$virtual_dir {", $nginxConf);
-			replaceFileContent('location \/.*?/samples {', "location /$virtual_dir/samples {", $nginxConf);
-			replaceFileContent('location \/.*?/wscbundle/ {', "location /$virtual_dir/wscbundle/ {", $nginxConf);
-			replaceFileContent('location \/.*?/api {', "location /$virtual_dir/api {", $nginxConf);
-		}
+
+		# Normalize virtual_dir: remove leading/trailing slashes
+		$virtual_dir =~ s/^\///;
+		$virtual_dir =~ s/\/$//;
+
+		my $vdir = $is_root_path ? '' : '/' . $virtual_dir;
+
+		# Change virtual dir inside NGINX config
+		my $main_location = $is_root_path ? '/' : $vdir;
+		replaceFileContent('location \/.*? {', "location $main_location {", $nginxConf);
+		replaceFileContent('location \/.*?/samples {', "location ${vdir}/samples {", $nginxConf);
+		replaceFileContent('location \/.*?/wscbundle/ {', "location ${vdir}/wscbundle/ {", $nginxConf);
+		replaceFileContent('location \/.*?/api {', "location ${vdir}/api {", $nginxConf);
 	}
 }
 

--- a/files/startService.sh
+++ b/files/startService.sh
@@ -28,11 +28,7 @@ fi
 # Generate self-signed certificates if HTTPS is enabled and no certs are provided
 if [ "$WPR_PROTOCOL" = "1" ]; then
     if [ ! -f "${WPR_CERT_DIR}/${WPR_CERT_FILE_NAME}" ] || [ ! -f "${WPR_CERT_DIR}/${WPR_CERT_KEY_NAME}" ]; then
-        # Use localhost as CN when WPR_DOMAIN_NAME is unset, empty, or '_' (NGINX catch-all)
-        CERT_CN="${WPR_DOMAIN_NAME:-localhost}"
-        if [ "$CERT_CN" = "_" ]; then
-            CERT_CN="localhost"
-        fi
+        CERT_CN="localhost"
         echo "$(date '+%m/%d/%y:%H:%M:%S.%3N')   No SSL certificates found. Generating self-signed certificate for CN=${CERT_CN}..."
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout "${WPR_CERT_DIR}/${WPR_CERT_KEY_NAME}" \

--- a/files/startService.sh
+++ b/files/startService.sh
@@ -28,11 +28,16 @@ fi
 # Generate self-signed certificates if HTTPS is enabled and no certs are provided
 if [ "$WPR_PROTOCOL" = "1" ]; then
     if [ ! -f "${WPR_CERT_DIR}/${WPR_CERT_FILE_NAME}" ] || [ ! -f "${WPR_CERT_DIR}/${WPR_CERT_KEY_NAME}" ]; then
-        echo "$(date '+%m/%d/%y:%H:%M:%S.%3N')   No SSL certificates found. Generating self-signed certificate for CN=${WPR_DOMAIN_NAME:-localhost}..."
+        # Use localhost as CN when WPR_DOMAIN_NAME is unset, empty, or '_' (NGINX catch-all)
+        CERT_CN="${WPR_DOMAIN_NAME:-localhost}"
+        if [ "$CERT_CN" = "_" ]; then
+            CERT_CN="localhost"
+        fi
+        echo "$(date '+%m/%d/%y:%H:%M:%S.%3N')   No SSL certificates found. Generating self-signed certificate for CN=${CERT_CN}..."
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout "${WPR_CERT_DIR}/${WPR_CERT_KEY_NAME}" \
             -out "${WPR_CERT_DIR}/${WPR_CERT_FILE_NAME}" \
-            -subj "/CN=${WPR_DOMAIN_NAME:-localhost}" 2>/dev/null
+            -subj "/CN=${CERT_CN}" 2>/dev/null
         echo "$(date '+%m/%d/%y:%H:%M:%S.%3N')   Self-signed certificate created: ${WPR_CERT_DIR}/${WPR_CERT_FILE_NAME}, ${WPR_CERT_DIR}/${WPR_CERT_KEY_NAME}"
         echo "$(date '+%m/%d/%y:%H:%M:%S.%3N')   For production, mount real certificates to ${WPR_CERT_DIR}/"
     fi


### PR DESCRIPTION
# Enable wildcard domain and root path support

## Summary

Remove `WPR_DOMAIN_NAME` parameter and add support for root virtual directory deployment.

## Changes

### Unrestricted domain access
- Resolves #84 
- **Remove** `WPR_DOMAIN_NAME`, with a single `default_server` block, nginx `server_name` has no effect regardless of its value. The parameter provided no real access control and created a false sense of security.
- Parameter removed from all Dockerfiles (Ubuntu, RedHat, prebuilt), perl scripts, startService.sh, and README
- Verification URL now always displays <host> placeholder

**Previously:** `WPR_DOMAIN_NAME` appeared to restrict domain access via server_name, but the default_server flag caused nginx to serve all requests regardless.

**Now:** The container accepts requests from any domain. The misleading parameter is removed.

### Root virtual directory support
- Resolves #83 
- **Support `WPR_VIRTUAL_DIR=/`** (or empty string) to run at root path
- Fix slash normalization in `configureWebServer.pl`:
- Strip leading/trailing slashes
- Prevent double slashes in NGINX `location` directives
- Handle root path: `location / {`, `location /samples {`, `location /api {`
- Handle default path: `location /wscservice {`, `location /wscservice/samples {`, etc.
- Update URL display in `configureFiles.pl` for root path compatibility
- Update README to document root path option

**Previously:** Virtual directory always required subdirectory. Root path generated invalid NGINX configs with double slashes.

**Now:** Users can set `WPR_VIRTUAL_DIR=/` to deploy at root path (default remains `wscservice`).

## Breaking changes

**BREAKING CHANGE:** `WPR_DOMAIN_NAME` build argument and environment variable are removed.

**Impact:** Passing --env WPR_DOMAIN_NAME=... at runtime is silently ignored. Build args referencing it will produce a Docker warning.

**Migration:** Remove `WPR_DOMAIN_NAME` from your `docker run` commands, Dockerfiles, and compose files.