### PR TITLE
WP-7202: Fix style guide path

### DIFF
--- a/files/configureFiles.pl
+++ b/files/configureFiles.pl
@@ -56,8 +56,8 @@ sub configureUserAndCustomDictionaries
 		system("mv $serverPath/CustDictConfig.xml $cust_dict_conf");
 	}
 	
-	replaceFileContent({ '<StyleGuideCheck Enabled="(true|false)">[\s]*?<DirectoryPath>[\w\\\/:]*?<\/DirectoryPath>[\s]*?<\/StyleGuideCheck>' =>
-		"<StyleGuideCheck Enabled=\"true\">\n\t\t<DirectoryPath>$style_guide_path</DirectoryPath>\n\t</StyleGuideCheck>" }, $server_config_path);
+	replaceFileContent({ '<StyleGuideCheck Enabled="(true|false)">[\s]*?<DirectoryPath>[\w\\\/:]*?<\/DirectoryPath>' =>
+		"<StyleGuideCheck Enabled=\"true\">\n\t\t<DirectoryPath>$style_guide_path</DirectoryPath>" }, $server_config_path);
 	
 	for my $file (<$serverPath/CustomDictionaries/*.txt>)
 	{


### PR DESCRIPTION
This PR fixes setting of `DirectoryPath` tag value in AppServerX.xml, after changes to this section in v6.13.0.