### PR TITLE
fix: activate the license when license.xml is empty, not only when mi…

### DIFF
--- a/files/startService.sh
+++ b/files/startService.sh
@@ -21,7 +21,11 @@ fi
 
 # activate a license automatically
 LicenseFile="${WPR_WSC_SERVICE_FILES_PATH}/license/license.xml"
-if ! [ -f "${LicenseFile}" ]; then
+
+# An unactivated license.xml is empty rather than absent: AppServer creates it on its first load
+# so that the inode the license is bound to exists. Test for content, not for existence, or a
+# container started once without a ticket would never activate again.
+if [ ! -s "${LicenseFile}" ]; then
    ./AppServerX -activateLicense ${WPR_LICENSE_TICKET_ID} -y
 fi
 


### PR DESCRIPTION
An unactivated license.xml is not absent, it is empty: AppServer creates it on its first load so that the inode the license is bound to exists.

startService.sh tested for existence, and an empty file satisfies -f. So a container started once without a ticket left the file behind and never attempted activation again, silently ignoring a ticket supplied later. It bites on docker restart or a compose restart, and on any setup with the license directory on a volume.

The test is now -s, so an empty file no longer counts as an activated license.
